### PR TITLE
Bugfix/fix append to env content method

### DIFF
--- a/src/Console/Commands/MicroServiceInstallCommand.php
+++ b/src/Console/Commands/MicroServiceInstallCommand.php
@@ -76,11 +76,7 @@ class MicroServiceInstallCommand extends Command
 
     private function appendToEnvContent(string $envKey, string $envKeyValue = ''): void
     {
-        $this->envContent = append_to_env_content(
-            envContent: $this->envContent, 
-            envKey: $envKey, 
-            envKeyValue: $envKeyValue
-        );
+        $this->envContent = append_to_env_content(envContent: $this->envContent, envKey: $envKey, envKeyValue: $envKeyValue);
     }
 
     private function publishConfiguration()

--- a/src/Console/Commands/MicroServiceInstallCommand.php
+++ b/src/Console/Commands/MicroServiceInstallCommand.php
@@ -42,10 +42,10 @@ class MicroServiceInstallCommand extends Command
         $this->envContent = \file_get_contents($this->envFile);
         $this->envContent .= "\n";
         $this->envKeys = [
-            'MS_SECURE_REQUESTS_ONLY' => $this->appendToEnvContent('MS_SECURE_REQUESTS_ONLY', '"true"'),
+            'MS_SECURE_REQUESTS_ONLY' => $this->appendToEnvContent('MS_SECURE_REQUESTS_ONLY', 'true'),
             'MS_GLOBAL_PROJECT_SECRET' => $this->appendToEnvContent('MS_GLOBAL_PROJECT_SECRET', ''),
-            'MS_LOCAL_SECRET' => $this->appendToEnvContent('MS_LOCAL_SECRET', generate_local_secret(16)),
-            'MS_DISABLE_PACKAGE_MIDDLEWARE' => $this->appendToEnvContent('MS_DISABLE_PACKAGE_MIDDLEWARE', '"true"'),
+            'MS_LOCAL_SECRET' => $this->appendToEnvContent('MS_LOCAL_SECRET', '"' . generate_local_secret(16) . '"'),
+            'MS_DISABLE_PACKAGE_MIDDLEWARE' => $this->appendToEnvContent('MS_DISABLE_PACKAGE_MIDDLEWARE', 'true'),
         ];
     }
 

--- a/src/Console/Commands/MicroServiceInstallCommand.php
+++ b/src/Console/Commands/MicroServiceInstallCommand.php
@@ -74,16 +74,13 @@ class MicroServiceInstallCommand extends Command
         return Command::SUCCESS;
     }
 
-    private function appendToEnvContent(string $envKey, string $envKeyValue = '')
+    private function appendToEnvContent(string $envKey, string $envKeyValue = ''): void
     {
-        append_to_env_content(envKey: $envKey, envKeyValue: $envKeyValue);
-        // $keyPosition = \strpos($this->envContent, "{$envKey}=");
-        // $endOfLinePosition = \strpos($this->envContent, "\n", $keyPosition);
-        // $oldValue = \substr($this->envContent, $keyPosition, $endOfLinePosition - $keyPosition);
-        // $envKeyValue = $keyPosition ? \explode('=', $oldValue)[1] : $envKeyValue;
-        // $this->envContent = ($keyPosition && $endOfLinePosition && $oldValue)
-        //                     ? \str_replace($oldValue, "{$envKey}={$envKeyValue}", $this->envContent)
-        //                     : $this->envContent . "{$envKey}={$envKeyValue}\n";
+        $this->envContent = append_to_env_content(
+            envContent: $this->envContent, 
+            envKey: $envKey, 
+            envKeyValue: $envKeyValue
+        );
     }
 
     private function publishConfiguration()

--- a/src/Helpers/MicroServiceHelperFunctions.php
+++ b/src/Helpers/MicroServiceHelperFunctions.php
@@ -21,17 +21,14 @@ if (! function_exists('request_passed_ssl_configuration')) {
 }
 
 if (! function_exists('append_to_env_content')) {
-    function append_to_env_content(string $envKey, string $envKeyValue = '')
+    function append_to_env_content(string $envContent, string $envKey, string $envKeyValue = '')
     {
-        $envFile = app()->environmentFilePath();
-        $envContent = \file_get_contents($envFile) . "\n";
-
         $keyPosition = \strpos($envContent, "{$envKey}=");
         $endOfLinePosition = \strpos($envContent, "\n", $keyPosition);
         $oldValue = \substr($envContent, $keyPosition, $endOfLinePosition - $keyPosition);
-        $envKeyValue = $keyPosition ? \explode('=', $oldValue)[1] : $envKeyValue;
-        $envContent = ($keyPosition && $endOfLinePosition && $oldValue)
+
+        return ($keyPosition && $endOfLinePosition && $oldValue)
                             ? \str_replace($oldValue, "{$envKey}={$envKeyValue}", $envContent)
-                            : $envContent . "{$envKey}={$envKeyValue}";
+                            : $envContent . "{$envKey}={$envKeyValue}\n";
     }
 }

--- a/src/Helpers/MicroServiceHelperFunctions.php
+++ b/src/Helpers/MicroServiceHelperFunctions.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Facades\Log;
+
 if (! function_exists('generate_local_secret')) {
     function generate_local_secret($length = 10, $intOnly = false, $prefix = null) {
         if (\strlen($prefix) > $length) abort(500, 'wrong helper function usage from backend');
@@ -24,11 +26,24 @@ if (! function_exists('append_to_env_content')) {
     function append_to_env_content(string $envContent, string $envKey, string $envKeyValue = '')
     {
         $keyPosition = \strpos($envContent, "{$envKey}=");
+
+        if ($keyPosition) {
+            return change_env_key_value(envContent: $envContent, envKey: $envKey, envKeyValue: $envKeyValue);
+        }
+
+        return $envContent . "{$envKey}={$envKeyValue}\n";
+    }
+}
+
+if (! function_exists('change_env_key_value')) {
+    function change_env_key_value(string $envContent, string $envKey, string $envKeyValue = '')
+    {
+        $keyPosition = \strpos($envContent, "{$envKey}=");
         $endOfLinePosition = \strpos($envContent, "\n", $keyPosition);
         $oldValue = \substr($envContent, $keyPosition, $endOfLinePosition - $keyPosition);
 
         return ($keyPosition && $endOfLinePosition && $oldValue)
-                            ? \str_replace($oldValue, "{$envKey}={$envKeyValue}", $envContent)
-                            : $envContent . "{$envKey}={$envKeyValue}\n";
+            ? \str_replace($oldValue, "{$envKey}={$envKeyValue}", $envContent)
+            : append_to_env_content(envContent: $envContent, envKey: $envKey, envKeyValue: $envKeyValue);
     }
 }

--- a/src/Helpers/MsHttp.php
+++ b/src/Helpers/MsHttp.php
@@ -237,7 +237,18 @@ class MsHttp
                 ],
             );
         });
-        append_to_env_content(envKey:'MS_LOCAL_SECRET', envKeyValue: $secret);
+        
+        $envFile = App::environmentFilePath();
+        $envContent = \file_get_contents($envFile);
+
+        $envContent = append_to_env_content(
+            envContent: $envContent, 
+            envKey: 'MS_LOCAL_SECRET', 
+            envKeyValue: $secret
+        );
+
+        \file_put_contents($envFile, $envContent);
+
         Artisan::call('config:cache');
     }
 

--- a/src/Helpers/MsHttp.php
+++ b/src/Helpers/MsHttp.php
@@ -241,11 +241,7 @@ class MsHttp
         $envFile = App::environmentFilePath();
         $envContent = \file_get_contents($envFile);
 
-        $envContent = append_to_env_content(
-            envContent: $envContent, 
-            envKey: 'MS_LOCAL_SECRET', 
-            envKeyValue: $secret
-        );
+        $envContent = change_env_key_value(envContent: $envContent, envKey: 'MS_LOCAL_SECRET', envKeyValue: $secret);
 
         \file_put_contents($envFile, $envContent);
 


### PR DESCRIPTION
- fix append_to_env_content helper method not adding the new keys.
- fix not updating the old values if the key exists.
- wrap the string values in a double quotes.
- remove the quotes from boolean values.